### PR TITLE
Fix heap buffer overflows caused by missing NULL terminators

### DIFF
--- a/src/Caesar.c
+++ b/src/Caesar.c
@@ -55,9 +55,8 @@ int main() {
 	        buffer[BUFFER_LENGTH - 1] = '\0';
 	    }
 	   
-		char* userInput = (char *) malloc(strlen(buffer)*sizeof(char));
-		
-		for(int i=0;i<strlen(buffer);i++)
+		char* userInput = (char *) malloc((strlen(buffer) + 1) *sizeof(char));
+		for(int i=0;i<strlen(buffer) + 1;i++)
 		{
 			userInput[i] = buffer[i];
 		}

--- a/src/Caesar_Decrypt.c
+++ b/src/Caesar_Decrypt.c
@@ -55,9 +55,9 @@ int main() {
 	        buffer[BUFFER_LENGTH - 1] = '\0';
 	    }
 	   
-		char* userInput = (char *) malloc(strlen(buffer)*sizeof(char));
+		char* userInput = (char *) malloc((strlen(buffer) + 1)*sizeof(char));
 		
-		for(int i=0;i<strlen(buffer);i++)
+		for(int i=0;i<strlen(buffer)+1;i++)
 		{
 			userInput[i] = buffer[i];
 		}


### PR DESCRIPTION
This bug was automatically found by executing the program with [Safe Sulong](https://github.com/graalvm/sulong/blob/master/docs/SAFE-SULONG.md).